### PR TITLE
Append seed results to merged output

### DIFF
--- a/src/sparqlRunner.ts
+++ b/src/sparqlRunner.ts
@@ -357,6 +357,7 @@ async function run(
 
       seedResult =  await resolveNameQueries(seed, "en")
       console.log(`✅ ${seed}: variants=${seedResult.variants.length}, translations=${seedResult.translations.length}`);
+      mergedResults.push(seedResult);
     } catch (err) {
       console.error(`❌ ${seed}:`, err);
       throw new Error (err as any);


### PR DESCRIPTION
## Summary
- append each resolved seed result to the merged results array as soon as it is available

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7145b8f40832f992c36023d14069a