### PR TITLE
Add SemanticQuery tests and adjust Jest setup

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,7 @@
+export class ConfigManager {
+  static config(rootPath: string): void {
+    // Minimal configuration hook used by the Jest global setup.
+    // Store the resolved root path so other modules could reuse it if needed.
+    process.env.PROJECT_ROOT = rootPath;
+  }
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  roots: ["<rootDir>/src/v5/tests"],
+  roots: ["<rootDir>/src/__tests__"],
   testMatch: ["**/*.test.ts"],
   //testMatch: ["**/src/v5/tests/**/*.test.ts"], // només executa els tests de v5
   moduleFileExtensions: ["ts", "js", "json"],
@@ -13,8 +13,8 @@ module.exports = {
   moduleNameMapper: {
     "^\\./services/NameService$": "<rootDir>/src/v5/services/NameService.ts",
   },
-  globalSetup: "<rootDir>/src/v5/jest.global-setup.ts",
-  globalTeardown: "<rootDir>/src/v5/jest.global-teardown.ts",
+  globalSetup: "<rootDir>/jest.global-setup.ts",
+  globalTeardown: "<rootDir>/jest.global-teardown.ts",
   // 👇 Coverage
   collectCoverage: true,
   collectCoverageFrom: [

--- a/jest.global-setup.ts
+++ b/jest.global-setup.ts
@@ -1,5 +1,5 @@
 // jest.global-setup.ts
-import path from "path";
+import * as path from "path";
 import { ConfigManager } from "./config";
 
 export default async function globalSetup() {

--- a/src/__tests__/semanticQuery.test.ts
+++ b/src/__tests__/semanticQuery.test.ts
@@ -1,0 +1,39 @@
+import { SemanticQuery } from "../sparqlRunner";
+
+describe("SemanticQuery", () => {
+  it("includes all provided concept QIDs in the VALUES clause", () => {
+    const query = SemanticQuery({ conceptQids: ["Q506", "Q756", "Q729"] });
+
+    expect(query).toContain("VALUES ?concept { wd:Q506 wd:Q756 wd:Q729 }");
+  });
+
+  it("respects custom languages while keeping order", () => {
+    const query = SemanticQuery({
+      conceptQids: ["Q506"],
+      languages: ["ca", "en", "es"],
+    });
+
+    expect(query).toContain(
+      'SERVICE wikibase:label { bd:serviceParam wikibase:language "ca,en,es". }'
+    );
+  });
+
+  it("uses the default language list when none is provided", () => {
+    const query = SemanticQuery({ conceptQids: ["Q506"] });
+
+    expect(query).toContain(
+      'SERVICE wikibase:label { bd:serviceParam wikibase:language "en,es,ca,fr,de". }'
+    );
+  });
+
+  it("applies the specified limit and defaults to 200", () => {
+    const customLimitQuery = SemanticQuery({
+      conceptQids: ["Q506"],
+      limit: 75,
+    });
+    const defaultLimitQuery = SemanticQuery({ conceptQids: ["Q506"] });
+
+    expect(customLimitQuery.trim().endsWith("LIMIT 75")).toBe(true);
+    expect(defaultLimitQuery.trim().endsWith("LIMIT 200")).toBe(true);
+  });
+});

--- a/src/sparqlRunner.ts
+++ b/src/sparqlRunner.ts
@@ -397,4 +397,6 @@ function main(){
   run(file, rate, queries, exec);
 }
 
-main();
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
## Summary
- update Jest configuration to use the project test directory and root-level setup scripts
- add lightweight ConfigManager stub and adjust setup import for compatibility
- guard the CLI entry point and add SemanticQuery unit tests for concepts, languages, and limits

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7196e9ae4832f9d98f68d5844d52a